### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test-core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "test-core",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "3.22.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/test-core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Core library with testing functionalities for flowbuild",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.1.1](https://github.com/flow-build/test-core/releases/tag/v1.1.1)